### PR TITLE
fix parseSeedPhrase result destructuring in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ const { parseSeedPhrase, generateSeedPhrase } = require('near-seed-phrase');
 const {seedPhrase, publicKey, secretKey} = generateSeedPhrase()
 
 // To recover keys from the seed phrase
-const { pubKey, secKey } = parseSeedPhrase(seedPhrase);
+const { publicKey, secretKey } = parseSeedPhrase(seedPhrase);
 ```


### PR DESCRIPTION
current README uses destructuring with incorrect property names, resulting in `undefined` values